### PR TITLE
Fix the issue of cancelled operation still running.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ numbers.
 
 ## 0.1.0 FUTURE
 
++ Fix the issue where the transcribe process is not cancelled properly [0.0.8]
 + Add a save button on the log page [0.0.7]
 + Add an alert popup window when no file is provided for transcription [0.0.6]
 + Add an about dialog of the app [0.0.5]

--- a/lib/language_process.dart
+++ b/lib/language_process.dart
@@ -502,11 +502,10 @@ class LanguageProcessPageState extends State<LanguageProcessPage> {
 
   Future<void> runExternalCommand(String filePath, WidgetRef ref) async {
     if (isProcessRunning) {
-      debugPrint('A process is already running. Please wait until it finishes.');
       return; // Prevent a new process if one is already running
     }
-    isProcessRunning = true;  // Mark that a process is now running
-   _cancelled = false; // Reset the cancellation flag
+    isProcessRunning = true; // Mark that a process is now running
+    _cancelled = false; // Reset the cancellation flag
     try {
       // Escape spaces in the filePath
       String escapedFilePath = filePath.replaceAll(' ', '\\ ');
@@ -637,7 +636,6 @@ class LanguageProcessPageState extends State<LanguageProcessPage> {
       _cancelled = true; // Set the cancellation flag
       _runningProcess!.kill(ProcessSignal.sigint);
 
-
       // Wait for the process to terminate
       _runningProcess!.exitCode.then((_) {
         if (mounted) {
@@ -648,7 +646,7 @@ class LanguageProcessPageState extends State<LanguageProcessPage> {
             _outputController.text = 'Operation cancelled.';
             _runningProcess = null;
           });
-          debugPrint("Process successfully cancelled.");
+          debugPrint('Process successfully cancelled.');
           updateLog(ref, 'Operation cancelled.');
         }
       }).catchError((error) {
@@ -664,5 +662,4 @@ class LanguageProcessPageState extends State<LanguageProcessPage> {
       });
     }
   }
-
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: "A Flutter app for MLHub."
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 0.0.7+5
+version: 0.0.8+5
 
 environment:
   sdk: '>=3.2.3 <4.0.0'


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

-Fix the issue of the cancelled transcribe/translate operation still running.

- Link to associated issue: https://github.com/mlhubber/mlflutter/issues/12

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted:
  - [ ] There is a warning about "Long method", which will be fixed together with issue 13 later.
  - [ ] make: [metrics] Error 2 (ignored)
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [x] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [x] Merge dev into the branch
- [x] Resolve any conflicts
- [x] Add one line summary into CHANGELOG.md
- [x] Bump appropriate version number in pubspec.yaml
- [x] Push to git repository and review
- [ ] Merge PR into dev
