### PR TITLE
Add an alert popup window when no file provided.

### DIFF
--- a/lib/language_process.dart
+++ b/lib/language_process.dart
@@ -469,7 +469,32 @@ class LanguageProcessPageState extends State<LanguageProcessPage> {
   }
 
   void _runOrNot(WidgetRef ref) {
-    if (_droppedFiles.isNotEmpty && !_isRunning) {
+    // Alert user to provide an input file if none is provided
+    if (_droppedFiles.isEmpty) {
+      showDialog(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            title: const Text('Input File Missing'),
+            content: const Text(
+              'Please provide an audio or video file first, either drag-and-drop or Choose File.',
+            ),
+            actions: <Widget>[
+              TextButton(
+                child: const Text('OK'),
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+              ),
+            ],
+          );
+        },
+      );
+
+      return;
+    }
+
+    if (!_isRunning) {
       // Check MIME type
       var mimeType = lookupMimeType(_droppedFiles.first.path);
 


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Display an alert popup window that guides the user to provide an audio/video file for transcribe/translate, when tapping the RUN button but no input file is provided.

- Link to associated issue: https://github.com/mlhubber/mlflutter/issues/18

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted:
  - [ ] There is a warning about "Long method", which will be fixed together with issue 13 later.
  - [ ] make: [metrics] Error 2 (ignored)
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev
