### PR TITLE
AutoClose Navigation Drawer after choosing a destination

### DIFF
--- a/lib/features/language/language_process.dart
+++ b/lib/features/language/language_process.dart
@@ -41,6 +41,7 @@ import 'package:path/path.dart' as path_lib;
 
 import 'package:mlflutter/constants/language_constants.dart';
 import 'package:mlflutter/features/log.dart';
+import 'package:mlflutter/utils/get_file_info.dart';
 import 'package:mlflutter/utils/save_file.dart';
 import 'package:mlflutter/widgets/language_selection.dart';
 import 'package:mlflutter/widgets/item_selection.dart';
@@ -62,8 +63,10 @@ class LanguageProcessState extends State<LanguageProcess> {
   bool _cancelled = false; // Track whether the command is cancelled
   Process? _runningProcess; // Control the process running
   bool _isProcessRunning = false; //  Track whether a process is running
-  String dropAreaText = '';
+  String dropAreaText =
+      'Drag and drop area'; // Text to display in the drop area
   List<XFile> droppedFiles = []; // Store the paths of dropped files
+  String fileInfo = ''; // Store the file information
   final TextEditingController _outputController = TextEditingController();
 
   // 20240622 ting Commented out fetchSupportedLanguages() function which
@@ -205,16 +208,20 @@ class LanguageProcessState extends State<LanguageProcess> {
         const SizedBox(height: 8.0),
         FileDropTarget(
           droppedFiles: droppedFiles,
-          onFilesDropped: (files) {
+          onFilesDropped: (files) async {
             setState(() {
               droppedFiles.clear();
               if (files.isNotEmpty) {
                 droppedFiles.add(files.last); // Add only the most recent file
               }
+            });
+            fileInfo = await getFileInfo(files.last);
+            setState(() {
               dropAreaText =
-                  'Selected file:\n${droppedFiles.map((file) => file.path).join('\n')}';
+                  'Selected file:\n${droppedFiles.last.path}\n$fileInfo';
             });
           },
+          dropAreaText: dropAreaText,
         ),
         const SizedBox(height: 16.0),
 
@@ -313,8 +320,12 @@ class LanguageProcessState extends State<LanguageProcess> {
         setState(() {
           droppedFiles.clear(); // Clear previous files
           droppedFiles.add(XFile(result.files.single.path!));
-          dropAreaText =
-              'Selected file:\n${droppedFiles.map((file) => file.path).join('\n')}';
+        });
+      }
+      fileInfo = await getFileInfo(droppedFiles.last);
+      if (mounted) {
+        setState(() {
+          dropAreaText = 'Selected file:\n${droppedFiles.last.path}\n$fileInfo';
         });
       }
     }

--- a/lib/features/language/process.dart
+++ b/lib/features/language/process.dart
@@ -149,59 +149,11 @@ class LanguageProcessState extends State<LanguageProcess> {
         const SizedBox(height: 16.0),
 
         // Language options.
-        Row(
-          children: <Widget>[
-            Expanded(
-              child: InputLanguageDropdown(
-                selectedInputLanguage: selectedInputLanguage,
-                onChanged: (value) {
-                  setState(() => selectedInputLanguage = value);
-                },
-              ),
-            ),
-            if (widget.processType == ProcessType.translate) ...[
-              const SizedBox(width: 20.0),
-              Expanded(
-                child: OutputLanguageDropdown(
-                  selectedOutputLanguage: selectedOutputLanguage,
-                  onChanged: (value) {
-                    setState(() => selectedOutputLanguage = value);
-                  },
-                ),
-              ),
-            ],
-          ],
-        ),
+        buildLanguageSelection(),
         const SizedBox(height: 20.0),
 
         // File uploading and processing area.
-        Row(
-          children: [
-            const Text('Drop your file here:', style: TextStyle(fontSize: 18)),
-            const SizedBox(width: 10.0),
-            ElevatedButton(
-              onPressed: _pickFile,
-              style: ElevatedButton.styleFrom(
-                shape: const RoundedRectangleBorder(
-                  borderRadius: BorderRadius.all(Radius.circular(5)),
-                ),
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
-              ),
-              child: const Text('Choose File'),
-            ),
-            const SizedBox(width: 10.0),
-            ElevatedButton(
-              onPressed: droppedFiles.isNotEmpty ? () => _runOrNot(ref) : null,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: droppedFiles.isNotEmpty ? null : Colors.grey,
-                foregroundColor:
-                    droppedFiles.isNotEmpty ? null : Colors.black45,
-              ),
-              child: const Text('Run'),
-            ),
-          ],
-        ),
+        buildFileUploadAndRunButtons(ref),
         const SizedBox(height: 8.0),
         FileDropTarget(
           droppedFiles: droppedFiles,
@@ -219,67 +171,129 @@ class LanguageProcessState extends State<LanguageProcess> {
         const SizedBox(height: 16.0),
 
         // Output display and save-to-file button.
-        Row(
-          children: [
-            const Text('Output:', style: TextStyle(fontSize: 18)),
-            const SizedBox(width: 10.0),
-            ElevatedButton(
-              onPressed: _outputController.text.isNotEmpty
-                  ? () async {
-                      String defaultFileName =
-                          '${path_lib.basenameWithoutExtension(droppedFiles.first.path)}.$selectedFormat';
-                      String initialDirectory =
-                          path_lib.dirname(droppedFiles.first.path);
-                      String result = await saveToFile(
-                        content: _outputController.text,
-                        defaultFileName: defaultFileName,
-                        initialDirectory: initialDirectory,
-                      );
-                      if (mounted) {
-                        ScaffoldMessenger.of(context)
-                            .showSnackBar(SnackBar(content: Text(result)));
-                      }
-                    }
-                  : null,
-              style: ElevatedButton.styleFrom(
-                backgroundColor:
-                    _outputController.text.isNotEmpty ? null : Colors.grey,
-                foregroundColor:
-                    _outputController.text.isNotEmpty ? null : Colors.black45,
-              ),
-              child: const Text('Save'),
-            ),
-          ],
-        ),
+        buildOutputLabelAndSaveButton(),
         const SizedBox(height: 8.0),
+        buildOutputDisplayBox(),
+      ],
+    );
+  }
+
+  Widget buildLanguageSelection() {
+    return Row(
+      children: <Widget>[
         Expanded(
-          child: Container(
-            margin: const EdgeInsets.only(bottom: 3.0),
-            padding: const EdgeInsets.all(16.0),
-            decoration: BoxDecoration(
-              border: Border.all(color: Colors.black),
-              borderRadius: BorderRadius.circular(4.0),
+          child: InputLanguageDropdown(
+            selectedInputLanguage: selectedInputLanguage,
+            onChanged: (value) {
+              setState(() => selectedInputLanguage = value);
+            },
+          ),
+        ),
+        if (widget.processType == ProcessType.translate) ...[
+          const SizedBox(width: 20.0),
+          Expanded(
+            child: OutputLanguageDropdown(
+              selectedOutputLanguage: selectedOutputLanguage,
+              onChanged: (value) {
+                setState(() => selectedOutputLanguage = value);
+              },
             ),
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxHeight: 200),
-              child: SingleChildScrollView(
-                scrollDirection: Axis.vertical,
-                child: TextFormField(
-                  controller: _outputController,
-                  readOnly: true,
-                  maxLines: null, // Allows for any number of lines
-                  keyboardType: TextInputType.multiline,
-                  decoration: const InputDecoration(
-                    border: InputBorder.none,
-                    isDense: true,
-                    contentPadding: EdgeInsets.all(8),
-                  ),
-                ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget buildFileUploadAndRunButtons(WidgetRef ref) {
+    return Row(
+      children: [
+        const Text('Drop your file here:', style: TextStyle(fontSize: 18)),
+        const SizedBox(width: 10.0),
+        ElevatedButton(
+          onPressed: _pickFile,
+          style: ElevatedButton.styleFrom(
+            shape: const RoundedRectangleBorder(
+              borderRadius: BorderRadius.all(Radius.circular(5)),
+            ),
+            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+          ),
+          child: const Text('Choose File'),
+        ),
+        const SizedBox(width: 10.0),
+        ElevatedButton(
+          onPressed: droppedFiles.isNotEmpty ? () => _runOrNot(ref) : null,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: droppedFiles.isNotEmpty ? null : Colors.grey,
+            foregroundColor: droppedFiles.isNotEmpty ? null : Colors.black45,
+          ),
+          child: const Text('Run'),
+        ),
+      ],
+    );
+  }
+
+  Widget buildOutputLabelAndSaveButton() {
+    return Row(
+      children: [
+        const Text('Output:', style: TextStyle(fontSize: 18)),
+        const SizedBox(width: 10.0),
+        ElevatedButton(
+          onPressed: _outputController.text.isNotEmpty
+              ? () async {
+                  String defaultFileName =
+                      '${path_lib.basenameWithoutExtension(droppedFiles.first.path)}.$selectedFormat';
+                  String initialDirectory =
+                      path_lib.dirname(droppedFiles.first.path);
+                  String result = await saveToFile(
+                    content: _outputController.text,
+                    defaultFileName: defaultFileName,
+                    initialDirectory: initialDirectory,
+                  );
+                  if (mounted) {
+                    ScaffoldMessenger.of(context)
+                        .showSnackBar(SnackBar(content: Text(result)));
+                  }
+                }
+              : null,
+          style: ElevatedButton.styleFrom(
+            backgroundColor:
+                _outputController.text.isNotEmpty ? null : Colors.grey,
+            foregroundColor:
+                _outputController.text.isNotEmpty ? null : Colors.black45,
+          ),
+          child: const Text('Save'),
+        ),
+      ],
+    );
+  }
+
+  Widget buildOutputDisplayBox() {
+    return Expanded(
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 3.0),
+        padding: const EdgeInsets.all(16.0),
+        decoration: BoxDecoration(
+          border: Border.all(color: Colors.black),
+          borderRadius: BorderRadius.circular(4.0),
+        ),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxHeight: 200),
+          child: SingleChildScrollView(
+            scrollDirection: Axis.vertical,
+            child: TextFormField(
+              controller: _outputController,
+              readOnly: true,
+              maxLines: null, // Allows for any number of lines
+              keyboardType: TextInputType.multiline,
+              decoration: const InputDecoration(
+                border: InputBorder.none,
+                isDense: true,
+                contentPadding: EdgeInsets.all(8),
               ),
             ),
           ),
         ),
-      ],
+      ),
     );
   }
 

--- a/lib/mlhub.dart
+++ b/lib/mlhub.dart
@@ -69,7 +69,8 @@ class _MLHubMainPageState extends ConsumerState<MLHubMainPage> {
         child: Drawer(
           child: AppNavigationDrawer(
             selectedIndex: selectedIndex,
-            onDestinationSelected: (index) => _onDestinationSelected(index, context),
+            onDestinationSelected: (index) =>
+                _onDestinationSelected(index, context),
             appVersion: appVersion,
           ),
         ),

--- a/lib/mlhub.dart
+++ b/lib/mlhub.dart
@@ -31,6 +31,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:mlflutter/constants/app.dart';
 import 'package:mlflutter/navigation/drawer.dart';
 import 'package:mlflutter/navigation/page_router.dart';
+import 'package:mlflutter/widgets/about_button.dart';
 
 class MLHubMainPage extends ConsumerStatefulWidget {
   const MLHubMainPage({super.key});
@@ -76,6 +77,9 @@ class _MLHubMainPageState extends ConsumerState<MLHubMainPage> {
       appBar: AppBar(
         title: const Text('MLHub'),
         toolbarHeight: toolbarHeight,
+        actions: [
+          aboutButton(context, appVersion),
+        ],
       ),
       body: PageRouter.getPage(selectedIndex),
     );

--- a/lib/mlhub.dart
+++ b/lib/mlhub.dart
@@ -53,10 +53,11 @@ class _MLHubMainPageState extends ConsumerState<MLHubMainPage> {
     });
   }
 
-  void _onDestinationSelected(int index) {
+  void _onDestinationSelected(int index, BuildContext context) {
     setState(() {
       selectedIndex = index;
     });
+    Navigator.pop(context);
   }
 
   @override
@@ -67,7 +68,7 @@ class _MLHubMainPageState extends ConsumerState<MLHubMainPage> {
         child: Drawer(
           child: AppNavigationDrawer(
             selectedIndex: selectedIndex,
-            onDestinationSelected: _onDestinationSelected,
+            onDestinationSelected: (index) => _onDestinationSelected(index, context),
             appVersion: appVersion,
           ),
         ),

--- a/lib/navigation/drawer.dart
+++ b/lib/navigation/drawer.dart
@@ -26,7 +26,6 @@ library;
 import 'package:flutter/material.dart';
 
 import 'package:mlflutter/widgets/log_button.dart';
-import 'package:mlflutter/widgets/about_button.dart';
 import 'package:mlflutter/widgets/version_label.dart';
 
 class AppNavigationDrawer extends StatelessWidget {
@@ -51,7 +50,6 @@ class AppNavigationDrawer extends StatelessWidget {
           ),
         ),
         logButton(context, () => onDestinationSelected(4), selectedIndex == 4),
-        aboutButton(context, appVersion),
         versionLabel(appVersion),
       ],
     );

--- a/lib/utils/get_file_info.dart
+++ b/lib/utils/get_file_info.dart
@@ -1,0 +1,80 @@
+/// Get the file information like file size, audio/video length etc.
+///
+/// Copyright (C) 2024 The Authors
+///
+/// Licensed under the GNU General Public License, Version 3 (the "License");
+///
+/// License: https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <https://www.gnu.org/licenses/>.
+///
+/// Authors: Ting Tang
+
+library;
+
+import 'dart:async';
+import 'package:cross_file/cross_file.dart';
+import 'package:mime/mime.dart';
+import 'dart:io';
+
+Future<String> getFileInfo(XFile file) async {
+  String fileInfo = '';
+  String duration = '';
+  final mimeType = lookupMimeType(file.path);
+
+  // Calculate file size
+  final fileSize = await file.length();
+  String fileSizeStr;
+  if (fileSize < 1024) {
+    fileSizeStr = '$fileSize bytes';
+  } else if (fileSize < 1024 * 1024) {
+    fileSizeStr = '${(fileSize / 1024).toStringAsFixed(2)} KB';
+  } else {
+    fileSizeStr = '${(fileSize / (1024 * 1024)).toStringAsFixed(2)} MB';
+  }
+
+  // Get duration for audio and video files
+  if (mimeType != null &&
+      (mimeType.startsWith('audio/') || mimeType.startsWith('video/'))) {
+    try {
+      final result = await Process.run('ffmpeg', ['-i', file.path]);
+
+      // Extract duration from ffmpeg output
+      final durationRegExp = RegExp(r'Duration: (\d{2}):(\d{2}):(\d{2})');
+      final match = durationRegExp.firstMatch(result.stderr as String);
+      if (match != null) {
+        final hours = int.parse(match.group(1)!);
+        final minutes = int.parse(match.group(2)!);
+        final seconds = int.parse(match.group(3)!);
+
+        if (hours > 0) {
+          duration = '$hours h $minutes min $seconds sec';
+        } else if (minutes > 0) {
+          duration = '$minutes min $seconds sec';
+        } else {
+          duration = '$seconds sec';
+        }
+      }
+    } catch (e) {
+      return 'Error getting duration: $e';
+    }
+  }
+
+  fileInfo = 'File size: $fileSizeStr';
+  if (duration.isNotEmpty) {
+    fileInfo += '\nDuration: $duration';
+  }
+
+  return fileInfo;
+}

--- a/lib/widgets/about_button.dart
+++ b/lib/widgets/about_button.dart
@@ -26,10 +26,9 @@ library;
 import 'package:flutter/material.dart';
 
 Widget aboutButton(BuildContext context, String appVersion) {
-  return ListTile(
-    leading: const Icon(Icons.info),
-    title: const Text('About'),
-    onTap: () => showAboutDialog(
+  return IconButton(
+    icon: const Icon(Icons.info),
+    onPressed: () => showAboutDialog(
       context: context,
       applicationVersion: 'Current version: $appVersion',
       applicationLegalese: '© 2024 Authors',
@@ -42,6 +41,5 @@ Widget aboutButton(BuildContext context, String appVersion) {
         ),
       ],
     ),
-    selectedTileColor: Theme.of(context).colorScheme.primary.withOpacity(0.1),
   );
 }

--- a/lib/widgets/file_drop.dart
+++ b/lib/widgets/file_drop.dart
@@ -31,17 +31,19 @@ import 'package:desktop_drop/desktop_drop.dart';
 class FileDropTarget extends StatelessWidget {
   final List<XFile> droppedFiles;
   final ValueChanged<List<XFile>> onFilesDropped;
+  final String dropAreaText;
 
   const FileDropTarget({
     super.key,
     required this.droppedFiles,
     required this.onFilesDropped,
+    required this.dropAreaText,
   });
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      height: 80.0,
+      height: 100.0,
       decoration: BoxDecoration(
         border: Border.all(color: Colors.black),
         borderRadius: BorderRadius.circular(4.0),
@@ -54,14 +56,12 @@ class FileDropTarget extends StatelessWidget {
           }
         },
         child: Center(
-          child: droppedFiles.isEmpty
-              ? const Text(
-                  'Drag and drop area',
-                  style: TextStyle(color: Colors.grey),
-                )
-              : Text(
-                  'Selected file:\n${droppedFiles.map((file) => file.path).join('\n')}',
-                ),
+          child: Text(
+            dropAreaText,
+            style: droppedFiles.isEmpty
+                ? const TextStyle(color: Colors.grey)
+                : null,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- After the user chooses a destination to go from the navigation drawer, the drawer disappears by itself by popping the context out.

- Link to associated issue:  https://github.com/mlhubber/mlflutter/issues/25

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted:
  - [ ] lib/main.dart: STYLE   Block is empty. Empty blocks are often indicators of missing code.
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added reviewer request

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [x] Merge dev into the branch
- [x] Resolve any conflicts
- [x] Add one line summary into CHANGELOG.md
- [x] Bump appropriate version number in pubspec.yaml
- [x] Push to git repository and review
- [x] Merge PR into dev
