### PR TITLE
Retain states for language functionalities

### DIFF
--- a/lib/constants/language.dart
+++ b/lib/constants/language.dart
@@ -28,10 +28,11 @@ import 'package:mlflutter/widgets/item_selection.dart';
 // Define an enum to differentiate the modes
 enum ProcessType { transcribe, translate, identify }
 
-String selectedModel = 'OpenAI';
-String selectedFormat = 'txt';
-String? selectedInputLanguage = 'Not specified';
-String? selectedOutputLanguage = 'English';
+String selectedModelDefault = 'OpenAI';
+String selectedFormatDefault = 'txt';
+String? selectedInputLanguageDefault = 'Not specified';
+String? selectedOutputLanguageDefault = 'English';
+String dropAreaTextDefault = 'Drag and drop area';
 
 List<SelectableItem> models = [
   SelectableItem(name: 'OpenAI', isEnabled: true),

--- a/lib/features/language/process.dart
+++ b/lib/features/language/process.dart
@@ -41,6 +41,7 @@ import 'package:path/path.dart' as path_lib;
 
 import 'package:mlflutter/constants/language.dart';
 import 'package:mlflutter/features/log.dart';
+import 'package:mlflutter/providers/language.dart';
 import 'package:mlflutter/utils/get_file_info.dart';
 import 'package:mlflutter/utils/save_file.dart';
 import 'package:mlflutter/widgets/language_selection.dart';
@@ -48,7 +49,7 @@ import 'package:mlflutter/widgets/item_selection.dart';
 import 'package:mlflutter/widgets/file_drop.dart';
 import 'package:mlflutter/widgets/processing_overlay.dart';
 
-class LanguageProcess extends StatefulWidget {
+class LanguageProcess extends ConsumerStatefulWidget {
   final ProcessType processType;
 
   const LanguageProcess({super.key, required this.processType});
@@ -57,17 +58,28 @@ class LanguageProcess extends StatefulWidget {
   LanguageProcessState createState() => LanguageProcessState();
 }
 
-class LanguageProcessState extends State<LanguageProcess> {
+class LanguageProcessState extends ConsumerState<LanguageProcess> {
   bool _isProcessing =
       false; // Track whether ml command is running, so whether to display the processing overlay
   bool _cancelled = false; // Track whether the command is cancelled
   Process? _runningProcess; // Control the process running
   bool _isProcessRunning = false; //  Track whether a process is running
-  String dropAreaText =
-      'Drag and drop area'; // Text to display in the drop area
-  List<XFile> droppedFiles = []; // Store the paths of dropped files
   String fileInfo = ''; // Store the file information
   final TextEditingController _outputController = TextEditingController();
+  late StateProvider<LanguageState> stateProvider;
+
+  @override
+  void initState() {
+    super.initState();
+    switch (widget.processType) {
+      case ProcessType.transcribe:
+        stateProvider = transcribeStateProvider;
+      case ProcessType.translate:
+        stateProvider = translateStateProvider;
+      case ProcessType.identify:
+        stateProvider = identifyStateProvider;
+    }
+  }
 
   // 20240622 ting Commented out fetchSupportedLanguages() function which
   // fetches the list inputLanguageOptions using "ml supported openai" command
@@ -103,6 +115,11 @@ class LanguageProcessState extends State<LanguageProcess> {
 
   @override
   Widget build(BuildContext context) {
+    final state = ref.watch(stateProvider);
+
+    // Sync the controller with the state's outputText
+    _outputController.text = state.outputText;
+
     return Scaffold(
       body: Container(
         color: Theme.of(context).colorScheme.primaryContainer,
@@ -114,7 +131,7 @@ class LanguageProcessState extends State<LanguageProcess> {
                   padding: const EdgeInsets.all(16.0),
                   child:
                       // Apply padding only to main content
-                      buildMainContent(ref),
+                      buildMainContent(ref, state),
                 ),
                 // Present a processing page as the ml command is running
                 if (_isProcessing)
@@ -127,7 +144,7 @@ class LanguageProcessState extends State<LanguageProcess> {
     );
   }
 
-  Widget buildMainContent(WidgetRef ref) {
+  Widget buildMainContent(WidgetRef ref, LanguageState state) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
@@ -135,8 +152,12 @@ class LanguageProcessState extends State<LanguageProcess> {
         const Text('Models available:', style: TextStyle(fontSize: 18)),
         const SizedBox(height: 8.0),
         SelectionButtons(
-          selectedItem: selectedModel,
-          onItemSelected: (model) => setState(() => selectedModel = model),
+          selectedItem: state.selectedModel,
+          onItemSelected: (model) {
+            ref
+                .read(stateProvider.notifier)
+                .update((state) => state.copyWith(selectedModel: model));
+          },
           items: models,
         ),
         const SizedBox(height: 16.0),
@@ -147,56 +168,60 @@ class LanguageProcessState extends State<LanguageProcess> {
           const Text('Output format:', style: TextStyle(fontSize: 18)),
           const SizedBox(height: 8.0),
           SelectionButtons(
-            selectedItem: selectedFormat,
-            onItemSelected: (format) => setState(() => selectedFormat = format),
+            selectedItem: state.selectedFormat,
+            onItemSelected: (format) {
+              ref
+                  .read(stateProvider.notifier)
+                  .update((state) => state.copyWith(selectedFormat: format));
+            },
             items: formats,
           ),
           const SizedBox(height: 16.0),
 
           // Language options.
-          buildLanguageSelection(),
+          buildLanguageSelection(ref, state),
           const SizedBox(height: 20.0),
         ],
 
         // File uploading and processing area.
-        buildFileUploadAndRunButtons(ref),
+        buildFileUploadAndRunButtons(ref, state),
         const SizedBox(height: 8.0),
         FileDropTarget(
           height: widget.processType == ProcessType.identify ? 200.0 : 100.0,
-          droppedFiles: droppedFiles,
+          droppedFiles: state.droppedFiles,
           onFilesDropped: (files) async {
-            setState(() {
-              droppedFiles.clear();
-              if (files.isNotEmpty) {
-                droppedFiles.add(files.last); // Add only the most recent file
-              }
-            });
             fileInfo = await getFileInfo(files.last);
-            setState(() {
-              dropAreaText =
-                  'Selected file:\n${droppedFiles.last.path}\n$fileInfo';
-            });
+            ref.read(stateProvider.notifier).update(
+                  (state) => state.copyWith(
+                    droppedFiles: [files.last],
+                    dropAreaText:
+                        'Selected file:\n${(files.last).path}\n$fileInfo',
+                    outputText: '',
+                  ),
+                );
           },
-          dropAreaText: dropAreaText,
+          dropAreaText: state.dropAreaText,
         ),
         const SizedBox(height: 16.0),
 
         // Output display and save-to-file button.
-        buildOutputLabelAndSaveButton(),
+        buildOutputLabelAndSaveButton(state),
         const SizedBox(height: 8.0),
         buildOutputDisplayBox(),
       ],
     );
   }
 
-  Widget buildLanguageSelection() {
+  Widget buildLanguageSelection(WidgetRef ref, LanguageState state) {
     return Row(
       children: <Widget>[
         Expanded(
           child: InputLanguageDropdown(
-            selectedInputLanguage: selectedInputLanguage,
+            selectedInputLanguage: state.selectedInputLanguage,
             onChanged: (value) {
-              setState(() => selectedInputLanguage = value);
+              ref.read(stateProvider.notifier).update(
+                    (state) => state.copyWith(selectedInputLanguage: value),
+                  );
             },
           ),
         ),
@@ -204,9 +229,11 @@ class LanguageProcessState extends State<LanguageProcess> {
           const SizedBox(width: 20.0),
           Expanded(
             child: OutputLanguageDropdown(
-              selectedOutputLanguage: selectedOutputLanguage,
+              selectedOutputLanguage: state.selectedOutputLanguage,
               onChanged: (value) {
-                setState(() => selectedOutputLanguage = value);
+                ref.read(stateProvider.notifier).update(
+                      (state) => state.copyWith(selectedOutputLanguage: value),
+                    );
               },
             ),
           ),
@@ -215,7 +242,7 @@ class LanguageProcessState extends State<LanguageProcess> {
     );
   }
 
-  Widget buildFileUploadAndRunButtons(WidgetRef ref) {
+  Widget buildFileUploadAndRunButtons(WidgetRef ref, LanguageState state) {
     return Row(
       children: [
         const Text('Drop your file here:', style: TextStyle(fontSize: 18)),
@@ -232,10 +259,13 @@ class LanguageProcessState extends State<LanguageProcess> {
         ),
         const SizedBox(width: 10.0),
         ElevatedButton(
-          onPressed: droppedFiles.isNotEmpty ? () => _runOrNot(ref) : null,
+          onPressed: state.droppedFiles.isNotEmpty
+              ? () => _runOrNot(ref, state)
+              : null,
           style: ElevatedButton.styleFrom(
-            backgroundColor: droppedFiles.isNotEmpty ? null : Colors.grey,
-            foregroundColor: droppedFiles.isNotEmpty ? null : Colors.black45,
+            backgroundColor: state.droppedFiles.isNotEmpty ? null : Colors.grey,
+            foregroundColor:
+                state.droppedFiles.isNotEmpty ? null : Colors.black45,
           ),
           child: const Text('Run'),
         ),
@@ -243,7 +273,7 @@ class LanguageProcessState extends State<LanguageProcess> {
     );
   }
 
-  Widget buildOutputLabelAndSaveButton() {
+  Widget buildOutputLabelAndSaveButton(LanguageState state) {
     return Row(
       children: [
         const Text('Output:', style: TextStyle(fontSize: 18)),
@@ -252,9 +282,9 @@ class LanguageProcessState extends State<LanguageProcess> {
           onPressed: _outputController.text.isNotEmpty
               ? () async {
                   String defaultFileName =
-                      '${path_lib.basenameWithoutExtension(droppedFiles.first.path)}.$selectedFormat';
+                      '${path_lib.basenameWithoutExtension(state.droppedFiles.first.path)}.$state.selectedFormat';
                   String initialDirectory =
-                      path_lib.dirname(droppedFiles.first.path);
+                      path_lib.dirname(state.droppedFiles.first.path);
                   String result = await saveToFile(
                     content: _outputController.text,
                     defaultFileName: defaultFileName,
@@ -309,12 +339,12 @@ class LanguageProcessState extends State<LanguageProcess> {
   }
 
   // Check the input file type and run the command if it's an audio or video file
-  void _runOrNot(WidgetRef ref) {
-    var mimeType = lookupMimeType(droppedFiles.first.path);
+  void _runOrNot(WidgetRef ref, LanguageState state) {
+    var mimeType = lookupMimeType(state.droppedFiles.first.path);
     if (mimeType != null &&
         (mimeType.startsWith('audio/') || mimeType.startsWith('video/'))) {
       setState(() => _isProcessing = true);
-      runExternalCommand(droppedFiles.first.path, ref).then((_) {
+      runExternalCommand(state.droppedFiles.first.path, ref, state).then((_) {
         if (mounted) {
           setState(() => _isProcessing = false);
         }
@@ -326,6 +356,9 @@ class LanguageProcessState extends State<LanguageProcess> {
               'Input file does not look like an audio or video file, '
               'please check the input file type.';
         });
+        ref.read(stateProvider.notifier).update(
+              (state) => state.copyWith(outputText: _outputController.text),
+            );
       }
     }
   }
@@ -334,22 +367,25 @@ class LanguageProcessState extends State<LanguageProcess> {
     FilePickerResult? result = await FilePicker.platform.pickFiles();
 
     if (result != null) {
+      fileInfo = await getFileInfo(XFile(result.files.single.path!));
       if (mounted) {
-        setState(() {
-          droppedFiles.clear(); // Clear previous files
-          droppedFiles.add(XFile(result.files.single.path!));
-        });
-      }
-      fileInfo = await getFileInfo(droppedFiles.last);
-      if (mounted) {
-        setState(() {
-          dropAreaText = 'Selected file:\n${droppedFiles.last.path}\n$fileInfo';
-        });
+        ref.read(stateProvider.notifier).update(
+              (state) => state.copyWith(
+                droppedFiles: [XFile(result.files.single.path!)],
+                dropAreaText:
+                    'Selected file:\n${XFile(result.files.single.path!).path}\n$fileInfo',
+                outputText: '',
+              ),
+            );
       }
     }
   }
 
-  Future<void> runExternalCommand(String filePath, WidgetRef ref) async {
+  Future<void> runExternalCommand(
+    String filePath,
+    WidgetRef ref,
+    LanguageState state,
+  ) async {
     if (_isProcessRunning) {
       return; // Prevent a new process if one is already running
     }
@@ -367,13 +403,14 @@ class LanguageProcessState extends State<LanguageProcess> {
           // When selectedFormat is txt, do not add argument '-f txt'
           // because default ml command without '-f' specified will output text
           // one sentence per line which is more desired than whisper txt format.
-          String formatCommand =
-              selectedFormat == 'txt' ? '' : '-f $selectedFormat';
+          String format = state.selectedFormat;
+          String formatCommand = format == 'txt' ? '' : '-f $format';
 
-          String languageCommand = (selectedInputLanguage != null &&
-                  selectedInputLanguage != 'Not specified')
-              ? '-l $selectedInputLanguage'
-              : '';
+          String? language = state.selectedInputLanguage;
+          String languageCommand =
+              (language != null && language != 'Not specified')
+                  ? '-l $language'
+                  : '';
 
           String operation = widget.processType == ProcessType.transcribe
               ? 'transcribe'
@@ -428,6 +465,9 @@ class LanguageProcessState extends State<LanguageProcess> {
         setState(() {
           _outputController.text = completeOutput.trim();
         });
+        ref.read(stateProvider.notifier).update(
+              (state) => state.copyWith(outputText: _outputController.text),
+            );
       }
 
       debugPrint(completeOutput.trim());
@@ -435,6 +475,9 @@ class LanguageProcessState extends State<LanguageProcess> {
     } catch (e) {
       if (mounted) {
         setState(() => _outputController.text = 'Error: $e');
+        ref.read(stateProvider.notifier).update(
+              (state) => state.copyWith(outputText: _outputController.text),
+            );
       }
     } finally {
       // Ensure _runningProcess is cleared and mark that no process is running
@@ -459,6 +502,9 @@ class LanguageProcessState extends State<LanguageProcess> {
             _runningProcess = null;
           });
           updateLog(ref, 'Operation cancelled.');
+          ref.read(stateProvider.notifier).update(
+                (state) => state.copyWith(outputText: _outputController.text),
+              );
         }
       }).catchError((error) {
         if (mounted) {
@@ -469,6 +515,9 @@ class LanguageProcessState extends State<LanguageProcess> {
             _isProcessRunning = false;
             _runningProcess = null;
           });
+          ref.read(stateProvider.notifier).update(
+                (state) => state.copyWith(outputText: _outputController.text),
+              );
         }
       });
     }

--- a/lib/providers/language.dart
+++ b/lib/providers/language.dart
@@ -1,0 +1,86 @@
+/// The needed elements for storing language processing pages' states.
+///
+/// Copyright (C) 2024 The Authors
+///
+/// Licensed under the GNU General Public License, Version 3 (the "License");
+///
+/// License: https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <https://www.gnu.org/licenses/>.
+///
+/// Authors: Ting Tang
+
+library;
+
+import 'package:cross_file/cross_file.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:mlflutter/constants/language.dart';
+
+class LanguageState {
+  final String selectedModel;
+  final String selectedFormat;
+  final String? selectedInputLanguage;
+  final String? selectedOutputLanguage;
+  final List<XFile> droppedFiles;
+  final String dropAreaText;
+  final String outputText;
+
+  LanguageState({
+    String? selectedModel,
+    String? selectedFormat,
+    String? selectedInputLanguage,
+    String? selectedOutputLanguage,
+    List<XFile>? droppedFiles,
+    String? dropAreaText,
+    String? outputText,
+  })  : selectedModel = selectedModel ?? selectedModelDefault,
+        selectedFormat = selectedFormat ?? selectedFormatDefault,
+        selectedInputLanguage =
+            selectedInputLanguage ?? selectedInputLanguageDefault,
+        selectedOutputLanguage =
+            selectedOutputLanguage ?? selectedOutputLanguageDefault,
+        droppedFiles = droppedFiles ?? const [],
+        dropAreaText = dropAreaText ?? dropAreaTextDefault,
+        outputText = outputText ?? '';
+
+  LanguageState copyWith({
+    String? selectedModel,
+    String? selectedFormat,
+    String? selectedInputLanguage,
+    String? selectedOutputLanguage,
+    List<XFile>? droppedFiles,
+    String? dropAreaText,
+    String? outputText,
+  }) {
+    return LanguageState(
+      selectedModel: selectedModel ?? this.selectedModel,
+      selectedFormat: selectedFormat ?? this.selectedFormat,
+      selectedInputLanguage:
+          selectedInputLanguage ?? this.selectedInputLanguage,
+      selectedOutputLanguage:
+          selectedOutputLanguage ?? this.selectedOutputLanguage,
+      droppedFiles: droppedFiles ?? this.droppedFiles,
+      dropAreaText: dropAreaText ?? this.dropAreaText,
+      outputText: outputText ?? this.outputText,
+    );
+  }
+}
+
+final transcribeStateProvider =
+    StateProvider<LanguageState>((ref) => LanguageState());
+final translateStateProvider =
+    StateProvider<LanguageState>((ref) => LanguageState());
+final identifyStateProvider =
+    StateProvider<LanguageState>((ref) => LanguageState());

--- a/lib/widgets/file_drop.dart
+++ b/lib/widgets/file_drop.dart
@@ -58,7 +58,7 @@ class FileDropTarget extends StatelessWidget {
           }
         },
         child: Center(
-          child: Text(
+          child: SelectableText(
             dropAreaText,
             style: droppedFiles.isEmpty
                 ? const TextStyle(color: Colors.grey)


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- For language functionalities, retain the information like selected models/selected format/input files/outputs/..., so when the user goes to another page and comes back, previous information can still be displayed and used to run.

- Link to associated issue: https://github.com/mlhubber/mlflutter/issues/7

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted:
  - [ ] lib/main.dart line40: STYLE   Block is empty. Empty blocks are often indicators of missing code.
  - [ ] lib/features/language/process.dart: WARNING Long method `buildMainContent`. This method contains 55 lines with code.
  - [ ] lib/features/language/process.dart: WARNING Long method `runExternalCommand`. This method contains 61 lines with code.
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added reviewer request

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [x] Merge dev into the branch
- [x] Resolve any conflicts
- [x] Add one line summary into CHANGELOG.md
- [x] Bump appropriate version number in pubspec.yaml
- [x] Push to git repository and review
- [x] Merge PR into dev
